### PR TITLE
replaced Docker Hub by GHCR

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,6 +16,7 @@ jobs:
         uses: elgohr/Publish-Docker-Github-Action@master
         with:
           name: jacobtomlinson/gha-find-replace
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+          registry: ghcr.io
           tags: "latest,${{ env.RELEASE_VERSION }}"

--- a/action.yml
+++ b/action.yml
@@ -24,4 +24,4 @@ outputs:
     description: "The number of files which have been modified"
 runs:
   using: "docker"
-  image: "docker://jacobtomlinson/gha-find-replace:2.0.0"
+  image: "docker://ghcr.io/jacobtomlinson/gha-find-replace:2.0.0"


### PR DESCRIPTION
to stop hitting the pull limit at Docker Hub please move the Container Image to GHCR