### PR TITLE
Enable replace value to be an empty string

### DIFF
--- a/main.go
+++ b/main.go
@@ -122,7 +122,7 @@ func main() {
 	}
 
 	if replaceErr != nil {
-		panic(errors.New("gha-find-replace: expected with.replace to be a string"))
+		replace = ""
 	}
 
 	if regexErr != nil {


### PR DESCRIPTION
Currently it's not possible to replace the values with an empty string since it triggers this error. I think it should be possible to use an empty string as the replace value.