### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,7 +13,7 @@ jobs:
         id: get_version
         run: echo ::set-env name=RELEASE_VERSION::$(echo $GITHUB_REF | cut -d / -f 3)
       - name: Publish to Registry
-        uses: elgohr/Publish-Docker-Github-Action@master
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           name: jacobtomlinson/gha-find-replace
           username: ${{ github.actor }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,6 +16,7 @@ jobs:
         uses: elgohr/Publish-Docker-Github-Action@master
         with:
           name: jacobtomlinson/gha-find-replace
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+          registry: ghcr.io
           tags: "latest,${{ env.RELEASE_VERSION }}"

--- a/action.yml
+++ b/action.yml
@@ -24,4 +24,4 @@ outputs:
     description: "The number of files which have been modified"
 runs:
   using: "docker"
-  image: "docker://jacobtomlinson/gha-find-replace:2.0.0"
+  image: "docker://ghcr.io/jacobtomlinson/gha-find-replace:2.0.0"


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore