### PR TITLE
Fix action.yml: Bump to 3.0.2

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -24,4 +24,4 @@ outputs:
     description: "The number of files which have been modified"
 runs:
   using: "docker"
-  image: "docker://ghcr.io/jacobtomlinson/gha-find-replace:3.0.1"
+  image: "docker://ghcr.io/jacobtomlinson/gha-find-replace:3.0.2"

--- a/action.yml
+++ b/action.yml
@@ -24,4 +24,4 @@ outputs:
     description: "The number of files which have been modified"
 runs:
   using: "docker"
-  image: "docker://ghcr.io/jacobtomlinson/gha-find-replace:3.0.2"
+  image: "docker://ghcr.io/jacobtomlinson/gha-find-replace:3.0.3"


### PR DESCRIPTION
I got error `panic: gha-find-replace: expected with.replace to be a string` when I try to replace with an empty string.
I saw that you have already fixed it, but your `action.yml` version is not updated.