### PR TITLE
Remove deprecated ioutil and unused function

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -1,27 +1,26 @@
 package main
 
 import (
-	"io/ioutil"
 	"os"
 	"testing"
 )
 
 func TestHappyPath(t *testing.T) {
-	_ = os.Mkdir("out", 0755)
+	_ = os.Mkdir("out", 0o755)
 
-	if err := ioutil.WriteFile("out/data.txt", []byte("Hello world\n"), 0644); err != nil {
+	if err := os.WriteFile("out/data.txt", []byte("Hello world\n"), 0o644); err != nil {
 		t.Error(err)
 	}
 
-	os.Setenv("INPUT_INCLUDE", "out/data.txt")
-	os.Setenv("INPUT_EXCLUDE", "")
-	os.Setenv("INPUT_FIND", "world")
-	os.Setenv("INPUT_REPLACE", "there")
-	os.Setenv("GITHUB_OUTPUT", "out/output.txt")
+	t.Setenv("INPUT_INCLUDE", "out/data.txt")
+	t.Setenv("INPUT_EXCLUDE", "")
+	t.Setenv("INPUT_FIND", "world")
+	t.Setenv("INPUT_REPLACE", "there")
+	t.Setenv("GITHUB_OUTPUT", "out/output.txt")
 
 	main()
 
-	data, err := ioutil.ReadFile("out/data.txt")
+	data, err := os.ReadFile("out/data.txt")
 	if err != nil {
 		t.Error(err)
 	}


### PR DESCRIPTION
This pull request includes several changes to the `main.go` file, focusing on code cleanup and improvements to file handling. The most important changes include removing an unused function, replacing deprecated functions, and improving code readability.

Code cleanup and improvements:

* Removed the unused `getenvInt` function.
* Replaced deprecated `ioutil.ReadFile` and `ioutil.WriteFile` with `os.ReadFile` and `os.WriteFile` respectively for better performance and future compatibility. [[1]](diffhunk://#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261L79-R69) [[2]](diffhunk://#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261L91-R78)
* Consolidated the `os.OpenFile` call into a single line for improved readability.

File handling improvements:

* Updated the `setGithubEnvOutput` function to use `fmt.Fprintf` for writing to the file, enhancing clarity and performance.